### PR TITLE
Add RouteSettings parameter to RouterBuilder

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,8 +4,8 @@ import 'package:flutter_router/flutter_router.dart' as FRouter;
 
 void main() => runApp(MaterialApp(
   onGenerateRoute: FRouter.Router({
-    '/accounts/{id}': (context, match) => Account(match!.parameters['id']!),
-    '/': (context, match) => Index(),
+    '/accounts/{id}': (context, match, settings) => Account(match!.parameters['id']!),
+    '/': (context, match, settings) => Index(),
   }).get,
 ));
 

--- a/lib/flutter_router.dart
+++ b/lib/flutter_router.dart
@@ -4,7 +4,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:uri/uri.dart';
 
-typedef Widget RouterBuilder(BuildContext context, UriMatch? match);
+typedef Widget RouterBuilder(BuildContext context, UriMatch? match, RouteSettings settings);
 
 class Router extends _Router {
   Router(final Map<String, RouterBuilder> definitions) : super(definitions, page: (<Null>(settings, builder) => new MaterialPageRoute<Null>(builder: builder, settings: settings)));
@@ -22,7 +22,7 @@ abstract class _Router {
     final matches = this.definitions.keys.where((route) => UriParser(UriTemplate(route)).matches(Uri.parse(settings.name!)));
     final route = matches.length > 0 ? matches.first : null;
 
-    return null != route ? this.page(settings, (context)=> this.definitions[route]!(context, UriParser(UriTemplate(route)).match(Uri.parse(settings.name!)))) : null;
+    return null != route ? this.page(settings, (context)=> this.definitions[route]!(context, UriParser(UriTemplate(route)).match(Uri.parse(settings.name!)), settings)) : null;
   }
 
   final Map<String, RouterBuilder> definitions;


### PR DESCRIPTION
In some cases, we pass arguments using the `Navigator.pushNamed` method, so to make it easy to access them I pass the RouteSettings to RouterBuilder.

Example:

```
onGenerateRoute: Router({
  '/item/{id}': (context, match, settings) {
    return ItemPage(
      item: settings?.arguments as Item?,
      id: match!.parameters['id']!,
    );
  },
  '/': (context, match, settings) => const HomePage(),
}).get,
```

I'm trying to pass the `Item` to `ItemPage` side by side with `id`, so if the `item` argument is not `null`, I'll save redundant getting the item data from the backend.